### PR TITLE
[WIP: Do Not Merge] fix: Add Korean to English translation for Imagen image generation

### DIFF
--- a/backend/app/services/prompt_service.py
+++ b/backend/app/services/prompt_service.py
@@ -26,7 +26,7 @@ def get_gemini_prompt(product: str, product_description: str, persona_descriptio
     )
 
 def get_imagen_prompt(product: str, product_description: str, persona_description: Optional[str] = None, number_of_variations: int = 1) -> str: # Removed customer_type
-    return (
+    prompt = (
         f"Generate a high-quality advertisement image for the product: '{product}' "
         f"(Description: '{product_description}'). "
         f"{f'The image should visually resonate with the following persona: {persona_description}. ' if persona_description else 'The image should be generally appealing and highlight the product effectively. '}"
@@ -34,3 +34,9 @@ def get_imagen_prompt(product: str, product_description: str, persona_descriptio
         f"Style: Clean, modern, visually appealing. No text in image. "
         f"If generating multiple variations, ensure diversity in composition and perspective."
     )
+    
+    # Debug logging for Korean text issues
+    print(f"[DEBUG] Imagen prompt generated: {prompt}")
+    print(f"[DEBUG] Prompt contains Korean: {any(ord(char) >= 0xAC00 and ord(char) <= 0xD7A3 for char in prompt)}")
+    
+    return prompt

--- a/backend/app/services/translation_service.py
+++ b/backend/app/services/translation_service.py
@@ -1,0 +1,46 @@
+from app.services.vertex_ai_service import GenerativeModel, generation_config
+import re
+
+def translate_korean_to_english(text: str) -> str:
+    """
+    Translates Korean text to English using Gemini.
+    If the text doesn't contain Korean, returns it as-is.
+    """
+    # Check if text contains Korean characters
+    if not any(ord(char) >= 0xAC00 and ord(char) <= 0xD7A3 for char in text):
+        return text
+    
+    try:
+        model = GenerativeModel("gemini-2.0-flash")
+        
+        prompt = f"""Translate the following Korean text to English. 
+        If the text contains mixed Korean and English, translate only the Korean parts.
+        Provide only the translation without any explanation.
+        
+        Text: {text}
+        
+        Translation:"""
+        
+        response = model.generate_content([prompt], generation_config=generation_config)
+        
+        if response.candidates and response.candidates[0].content.parts:
+            translated = response.candidates[0].content.parts[0].text.strip()
+            print(f"[DEBUG] Translation: '{text}' -> '{translated}'")
+            return translated
+        else:
+            print(f"[WARNING] Translation failed, returning original text")
+            return text
+            
+    except Exception as e:
+        print(f"[ERROR] Translation error: {e}")
+        return text
+
+def translate_product_info(product: str, description: str) -> tuple[str, str]:
+    """
+    Translates product name and description from Korean to English.
+    Returns a tuple of (translated_product, translated_description).
+    """
+    translated_product = translate_korean_to_english(product)
+    translated_description = translate_korean_to_english(description)
+    
+    return translated_product, translated_description

--- a/backend/app/services/vertex_ai_service.py
+++ b/backend/app/services/vertex_ai_service.py
@@ -81,8 +81,12 @@ def generate_ad_text_with_gemini(prompt: str, num_variations: int = 1) -> list[s
     if not PROJECT_ID:
         return [f"Error: GCP_PROJECT_ID not configured. Cannot call Gemini for {num_variations} variations."]
     try:
-        # Log the prompt
-        logger.log_text(f"Gemini Prompt: {prompt}")
+        # Enhanced logging for debugging Korean text issues
+        logger.log_text(f"[DEBUG] Gemini Prompt: {prompt}")
+        logger.log_text(f"[DEBUG] Prompt contains Korean: {any(ord(char) >= 0xAC00 and ord(char) <= 0xD7A3 for char in prompt)}")
+        
+        import json
+        logger.log_text(f"[DEBUG] Prompt as JSON: {json.dumps(prompt, ensure_ascii=False)}")
         model = GenerativeModel(GEMINI_MODEL_NAME)
         response = model.generate_content([prompt], generation_config=generation_config)
         
@@ -118,8 +122,15 @@ def generate_ad_image_with_imagen(prompt: str, aspect_ratio: str = "1:1", number
     
     image_data_list = []
     try:
-        # Log the prompt
-        logger.log_text(f"Imagen Prompt: {prompt}")
+        # Enhanced logging for debugging Korean text issues
+        logger.log_text(f"[DEBUG] Imagen Prompt: {prompt}")
+        logger.log_text(f"[DEBUG] Prompt contains Korean: {any(ord(char) >= 0xAC00 and ord(char) <= 0xD7A3 for char in prompt)}")
+        logger.log_text(f"[DEBUG] Prompt length: {len(prompt)} characters")
+        
+        # Log the prompt in both original and encoded form
+        import json
+        logger.log_text(f"[DEBUG] Prompt as JSON: {json.dumps(prompt, ensure_ascii=False)}")
+        logger.log_text(f"[DEBUG] Prompt bytes: {prompt.encode('utf-8')}")
         model = ImageGenerationModel.from_pretrained(IMAGEN_MODEL_NAME)
         
         # Imagen's generate_images can take number_of_images directly

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -31,6 +31,12 @@ export const generateAdContent = async (payload: AdGenerationRequestPayload): Pr
     // Ensure number_of_variations is included in the payload sent to the backend.
     // The backend will default if not provided, but explicit is better.
     const requestPayload = { ...payload, number_of_variations: payload.number_of_variations || 3 };
+    
+    // Debug logging for Korean text issues
+    console.log('[DEBUG] Sending request with payload:', requestPayload);
+    console.log('[DEBUG] Product contains Korean:', /[\u3131-\uD79D]/.test(requestPayload.product));
+    console.log('[DEBUG] Description contains Korean:', /[\u3131-\uD79D]/.test(requestPayload.product_description));
+    
     const response = await axios.post<AdGenerationResponseData>(`${API_BASE_URL}/generate_ad_content`, requestPayload);
     return response.data;
   } catch (error) {


### PR DESCRIPTION
**Problem**
When Korean text is used for product names and descriptions, Imagen generates incorrect or unrelated images because the model doesn't understand Korean language inputs.

**Root Cause**
Imagen model is primarily trained on English data and cannot properly interpret Korean text
Korean product information was being passed directly to Imagen without translation
Solution
Implemented automatic Korean to English translation using Gemini before sending prompts to Imagen.

**Changes Made**
1. Added Translation Service (backend/app/services/translation_service.py)
Created new service to handle Korean to English translation using Gemini
Automatically detects Korean characters and translates only when needed
Gracefully handles translation failures by returning original text
2. Modified Ad Generation Router (backend/app/routers/ads.py)
Integrated translation service to translate product info before image generation
Maintains original Korean text for Gemini text generation (to produce Korean ad copy)
Uses translated English text for Imagen image generation
3. Enhanced Debugging Capabilities
Added comprehensive logging throughout the pipeline:
Frontend: Korean character detection in inputs
Backend: Request data validation and translation results
Services: Detailed prompt logging with Korean detection
Integrated with Google Cloud Logging for production debugging

AS-IS 
<img width="596" height="507" alt="Screenshot 2025-07-14 at 10 53 22 PM" src="https://github.com/user-attachments/assets/9d1b342e-70e2-4eb5-aa1f-82fadba00e6a" />


TO-BE
<img width="820" height="491" alt="Screenshot 2025-07-14 at 10 53 52 PM" src="https://github.com/user-attachments/assets/08add3bf-719f-4d7f-9d1a-e7d198cb1d75" />
